### PR TITLE
DP-5660-Fix query parsing and query serialization

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -71,6 +71,11 @@ dependencies {
     api 'org.apache.commons:commons-text:1.12.0'
 
     testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:4.11.0'
+}
+
+test {
+    jvmArgs '--add-opens', 'java.base/java.net=ALL-UNNAMED'
 }
 
 javadoc {

--- a/library/src/main/java/com/northconcepts/templatemaster/rest/Url.java
+++ b/library/src/main/java/com/northconcepts/templatemaster/rest/Url.java
@@ -78,7 +78,7 @@ public final class Url {
             }
 
             for (String param : query.split("&")) {
-                String pair[] = param.split("=");
+                String pair[] = param.split("=", 2);
                 String key = URLDecoder.decode(pair[0], ENCODING);
                 String value = null;
                 if (pair.length > 1) {
@@ -101,22 +101,25 @@ public final class Url {
     }
 
     private String queryParamsToString(Map<String, List<String>> queryParams) throws UnsupportedEncodingException {
-        String s = "";
+        StringBuilder sb = new StringBuilder();
         for (String key : queryParams.keySet()) {
-            if (!Util.isEmpty(s)) {
-                s += "&";
-            }
             List<String> values = queryParams.get(key);
             if (values == null || values.size() == 0) {
-                s += URLEncoder.encode(key, ENCODING);
+                if (sb.length() > 0) {
+                    sb.append("&");
+                }
+                sb.append(URLEncoder.encode(key, ENCODING));
             } else {
                 for (String value : values) {
-                    s += URLEncoder.encode(key, ENCODING) + "=" + URLEncoder.encode(value, ENCODING);
+                    if (sb.length() > 0) {
+                        sb.append("&");
+                    }
+                    sb.append(URLEncoder.encode(key, ENCODING)).append("=").append(URLEncoder.encode(value, ENCODING));
                 }
             }
         }
 
-        return s;
+        return sb.toString();
     }
 
     private static void setQuery(URI uri, String query) {

--- a/library/src/test/java/com/northconcepts/templatemaster/rest/TestUrl.java
+++ b/library/src/test/java/com/northconcepts/templatemaster/rest/TestUrl.java
@@ -32,7 +32,7 @@ public class TestUrl {
         Url url = new Url("https://example.com/path?a=1");
         Url result = url.setQueryParam("b", "2");
 
-        assertTrue(result.toString().contains("a=1"));
+        assertTrue(result.toString().contains("a=12"));
         assertTrue(result.toString().contains("b=2"));
     }
 

--- a/library/src/test/java/com/northconcepts/templatemaster/rest/TestUrl.java
+++ b/library/src/test/java/com/northconcepts/templatemaster/rest/TestUrl.java
@@ -32,7 +32,7 @@ public class TestUrl {
         Url url = new Url("https://example.com/path?a=1");
         Url result = url.setQueryParam("b", "2");
 
-        assertTrue(result.toString().contains("a=12"));
+        assertTrue(result.toString().contains("a=1"));
         assertTrue(result.toString().contains("b=2"));
     }
 

--- a/library/src/test/java/com/northconcepts/templatemaster/rest/TestUrl.java
+++ b/library/src/test/java/com/northconcepts/templatemaster/rest/TestUrl.java
@@ -1,0 +1,98 @@
+package com.northconcepts.templatemaster.rest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestUrl {
+
+    @Before
+    public void setUp() {
+        HttpServletRequest mockRequest = mock(HttpServletRequest.class);
+        when(mockRequest.getScheme()).thenReturn("https");
+        when(mockRequest.getHeader("x-forwarded-proto")).thenReturn(null);
+        RequestHolder.setHttpServletRequest(mockRequest);
+    }
+
+    @After
+    public void tearDown() {
+        RequestHolder.clearHttpServletRequest();
+    }
+
+
+    @Test
+    public void testSetQueryParam_addsNewParam() {
+        Url url = new Url("https://example.com/path?a=1");
+        Url result = url.setQueryParam("b", "2");
+
+        assertTrue(result.toString().contains("a=1"));
+        assertTrue(result.toString().contains("b=2"));
+    }
+
+    @Test
+    public void testSetQueryParam_replacesExistingParam() {
+        Url url = new Url("https://example.com/path?a=1&b=2");
+        Url result = url.setQueryParam("a", "99");
+
+        assertTrue(result.toString().contains("a=99"));
+        assertTrue(result.toString().contains("b=2"));
+        assertFalse(result.toString().contains("a=1"));
+    }
+
+    @Test
+    public void testSetQueryParam_nullValueRemovesParam() {
+        Url url = new Url("https://example.com/path?a=1&b=2");
+        Url result = url.setQueryParam("a", null);
+
+        assertFalse(result.toString().contains("a=1"));
+        assertTrue(result.toString().contains("b=2"));
+    }
+
+    @Test
+    public void testRemoveQueryParam_removesSpecifiedKeys() {
+        Url url = new Url("https://example.com/path?a=1&b=2&c=3");
+        Url result = url.removeQueryParam("a", "c");
+
+        assertFalse(result.toString().contains("a="));
+        assertTrue(result.toString().contains("b=2"));
+        assertFalse(result.toString().contains("c="));
+    }
+
+    @Test
+    public void testRetainQueryParam_keepsOnlySpecifiedKeys() {
+        Url url = new Url("https://example.com/path?a=1&b=2&c=3");
+        Url result = url.retainQueryParam("b");
+
+        assertFalse(result.toString().contains("a="));
+        assertTrue(result.toString().contains("b=2"));
+        assertFalse(result.toString().contains("c="));
+    }
+
+    @Test
+    public void testSetQueryParam_preservesValueWithEqualsSigns() {
+        Url url = new Url("https://example.com/path?token=abc%3D%3D");
+        Url result = url.setQueryParam("extra", "yes");
+
+        assertTrue("token value with '=' signs should be preserved",
+                result.toString().contains("token=abc%3D%3D"));
+        assertTrue(result.toString().contains("extra=yes"));
+    }
+
+    @Test
+    public void testRemoveQueryParam_preservesMultiValuedKey() {
+        Url url = new Url("https://example.com/path?c=red&c=blue&other=1");
+        Url result = url.removeQueryParam("other");
+
+        String s = result.toString();
+        assertTrue(s.contains("c=red"));
+        assertTrue(s.contains("c=blue"));
+        assertFalse(s.contains("other"));
+    }
+}


### PR DESCRIPTION
Use split("=", 2) when parsing query parameters so values containing '=' are preserved. Replace string concatenation with StringBuilder in queryParamsToString to improve performance and correctly manage '&' separators; also ensure key-only parameters are encoded properly. These changes improve correctness and efficiency when serializing and parsing URL query strings.