### PR TITLE
DP-5730-Use raw query and ignore empty params

### DIFF
--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -1,1 +1,1 @@
-version=3.0.7
+version=3.0.8

--- a/library/src/main/java/com/northconcepts/templatemaster/rest/Url.java
+++ b/library/src/main/java/com/northconcepts/templatemaster/rest/Url.java
@@ -72,12 +72,15 @@ public final class Url {
         try {
             Map<String, List<String>> queryParams = new LinkedHashMap<String, List<String>>();
 
-            String query = uri.getQuery();
+            String query = uri.getRawQuery();
             if (Util.isEmpty(query)) {
                 return queryParams;
             }
 
             for (String param : query.split("&")) {
+                if (param.isEmpty()) {
+                    continue;
+                }
                 String pair[] = param.split("=", 2);
                 String key = URLDecoder.decode(pair[0], ENCODING);
                 String value = null;

--- a/library/src/test/java/com/northconcepts/templatemaster/rest/TestUrl.java
+++ b/library/src/test/java/com/northconcepts/templatemaster/rest/TestUrl.java
@@ -95,4 +95,29 @@ public class TestUrl {
         assertTrue(s.contains("c=blue"));
         assertFalse(s.contains("other"));
     }
+
+    @Test
+    public void testParseQueryParams_noDoubleDecoding() {
+        Url url = new Url("https://example.com/path?path=%252Fhome");
+        Url result = url.setQueryParam("extra", "yes");
+
+        String s = result.toString();
+        assertTrue("Double-encoded value should only be decoded once",
+                s.contains("path=%252F") || s.contains("path=%252f"));
+        assertTrue(s.contains("extra=yes"));
+        assertFalse("Should not double-decode %252F into /",
+                s.contains("path=%2F") || s.contains("path=%2f") || s.contains("path=/"));
+    }
+
+    @Test
+    public void testParseQueryParams_ignoresEmptySegments() {
+        Url url = new Url("https://example.com/path?a=1&&b=2&");
+        Url result = url.setQueryParam("c", "3");
+
+        String s = result.toString();
+        assertTrue(s.contains("a=1"));
+        assertTrue(s.contains("b=2"));
+        assertTrue(s.contains("c=3"));
+        assertFalse("Should not contain empty key", s.contains("&&"));
+    }
 }


### PR DESCRIPTION
Use URI.getRawQuery() instead of getQuery() so manual URLDecoder.decode() operates on the raw percent-encoded query (preventing inadvertent double-decoding). Also skip empty query segments (e.g. from trailing or consecutive '&') to avoid processing empty parameters.